### PR TITLE
feat: websocket transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: crystal
-

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ http_client.basic_auth "rpc_user", "rpc_password"
 client = JsonRpc::HttpClient.new http_client
 
 # Check your balance!
-pp client.call(JsonRpc::Response(Float64), "getbalance")
+pp client.call(Float64, "getbalance")
 ```
 
 [Source](https://github.com/Papierkorb/json_rpc/tree/master/samples/http_client.cr)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JSON-RPC Client and Server [![Build Status](https://travis-ci.org/Papierkorb/json_rpc.svg?branch=master)](https://travis-ci.org/Papierkorb/json_rpc)
+# JSON-RPC Client and Server [![CI](https://github.com/Papierkorb/json_rpc/actions/workflows/ci.yml/badge.svg)](https://github.com/Papierkorb/json_rpc/actions/workflows/ci.yml)
 
 Use and provide services using JSON-RPC!
 
@@ -7,7 +7,7 @@ Use and provide services using JSON-RPC!
 | Transport | Client  | Server  |
 |-----------|---------|---------|
 | HTTP      | Yes     | Planned |
-| Websocket | Planned | Planned |
+| Websocket | Yes     | Planned |
 | TCP       | Yes     | Yes     |
 
 Custom transports can be easily created.  Have a look at `JsonRpc::TcpClient`.

--- a/samples/delayed_response.cr
+++ b/samples/delayed_response.cr
@@ -22,8 +22,8 @@ class MyHandler
   end
 
   # Will be called for all incoming invocation requests
-  def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request(JSON::Any), raw : String)
-    puts "Request from #{client.inspect} to #{request.method.inspect} using #{request.params.inspect}"
+  def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request, raw : String)
+    puts "Request from #{client.inspect} to #{request.method} using #{request.params.inspect}"
 
     case request.method
     when "ping"

--- a/samples/delayed_response.cr
+++ b/samples/delayed_response.cr
@@ -28,8 +28,8 @@ class MyHandler
     case request.method
     when "ping"
       delayed = request.respond_later client # Respond later...
-      run_intense_computation delayed # Do some asynchronous work
-      delayed # Signal that we will respond later!
+      run_intense_computation delayed        # Do some asynchronous work
+      delayed                                # Signal that we will respond later!
     else
       super
     end

--- a/samples/http_client.cr
+++ b/samples/http_client.cr
@@ -18,7 +18,7 @@ http_client.basic_auth username, password
 client = JsonRpc::HttpClient.new http_client
 
 # Get current balance!
-balance = client.call(JsonRpc::Response(Float64), "getbalance")
-#          The result will be a Float64 ^^^^^^^
+balance = client.call(Float64, "getbalance")
+#                     ^^^^^^^ The result will be a Float64
 
 puts "Current balance: #{balance}"

--- a/samples/tcp_chat.cr
+++ b/samples/tcp_chat.cr
@@ -62,7 +62,7 @@ class ChatServer
   def run
     puts "Now accepting connections!"
 
-    while socket = @server.accept? # Accept connections ...
+    while socket = @server.accept?   # Accept connections ...
       client = ChatClient.new socket # And register each new client
       puts "New connection from #{client.remote_address}"
 
@@ -77,7 +77,7 @@ class ChatServer
   def broadcast_message(message)
     # First, construct the notification.  Set the id to `nil`!
     json_data = JsonRpc::Request(String).new(nil, "message", message).to_json
-    @clients.each{|client| client.notify_raw json_data}
+    @clients.each &.notify_raw(json_data)
   end
 
   def setup_client_handlers(client)
@@ -110,7 +110,7 @@ else # Client mode
   end
 
   puts "Connected!"
-  while message = gets # Wait for user input
+  while message = gets               # Wait for user input
     client.notify "message", message # And send it off to the server
   end
 end

--- a/samples/tcp_chat.cr
+++ b/samples/tcp_chat.cr
@@ -76,7 +76,7 @@ class ChatServer
   # in bulk to many clients.
   def broadcast_message(message)
     # First, construct the notification.  Set the id to `nil`!
-    json_data = JsonRpc::Request(String).new(nil, "message", message).to_json
+    json_data = JsonRpc::Request.new(nil, "message", message).to_json
     @clients.each &.notify_raw(json_data)
   end
 

--- a/samples/tcp_client.cr
+++ b/samples/tcp_client.cr
@@ -11,5 +11,5 @@ socket = TCPSocket.new("localhost", 1234)
 client = JsonRpc::TcpClient.new socket # Turn it into a JSON-RPC connection
 
 puts "Calling ping method..."
-result = client.call JsonRpc::Response(String), "ping", [ Time.now ]
+result = client.call JsonRpc::Response(String), "ping", [Time.now]
 puts "Result: #{result.inspect}"

--- a/samples/tcp_client.cr
+++ b/samples/tcp_client.cr
@@ -11,5 +11,5 @@ socket = TCPSocket.new("localhost", 1234)
 client = JsonRpc::TcpClient.new socket # Turn it into a JSON-RPC connection
 
 puts "Calling ping method..."
-result = client.call JsonRpc::Response(String), "ping", [Time.now]
+result = client.call String, "ping", [Time.now]
 puts "Result: #{result.inspect}"

--- a/samples/tcp_server.cr
+++ b/samples/tcp_server.cr
@@ -14,11 +14,11 @@ class MyHandler
   def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request(JSON::Any), raw : String)
     puts "Request from #{client.inspect} to #{request.method.inspect} using #{request.params.inspect}"
 
-    case request.method # Handle it
-    when "ping" # Implement a ping method ..
+    case request.method        # Handle it
+    when "ping"                # Implement a ping method ..
       request.respond("Pong!") # .. which responds with a pong
-    else # Unknown method?
-      super # Respond with unknown method error
+    else                       # Unknown method?
+      super                    # Respond with unknown method error
     end
   end
 end

--- a/samples/tcp_server.cr
+++ b/samples/tcp_server.cr
@@ -11,8 +11,8 @@ class MyHandler
   include JsonRpc::Handler
 
   # Will be called for all incoming invocation requests
-  def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request(JSON::Any), raw : String)
-    puts "Request from #{client.inspect} to #{request.method.inspect} using #{request.params.inspect}"
+  def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request, raw : String)
+    puts "Request from #{client.inspect} to #{request.method} using #{request.params.inspect}"
 
     case request.method        # Handle it
     when "ping"                # Implement a ping method ..

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: json_rpc
 description: A JSON-RPC client and server library
-version: 0.1.1
+version: 1.0.0
 crystal: ">= 0.35.1, < 2.0.0"
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: json_rpc
 description: A JSON-RPC client and server library
 version: 0.1.1
-crystal: ">= 0.35, < 2"
+crystal: ">= 0.35.1, < 2.0.0"
 license: MIT
 
 authors:

--- a/shard.yml
+++ b/shard.yml
@@ -6,6 +6,7 @@ license: MIT
 
 authors:
   - Stefan Merettig <stefan-merettig@nuriaproject.org>
+  - Caspian Baska <caspianbaska@gmail.com>
 
 dependencies:
   cute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: json_rpc
 description: A JSON-RPC client and server library
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Stefan Merettig <stefan-merettig@nuriaproject.org>
@@ -9,6 +9,6 @@ dependencies:
   cute:
     github: Papierkorb/cute
 
-crystal: 0.22.0
+crystal: 0.34.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,8 @@
 name: json_rpc
 description: A JSON-RPC client and server library
 version: 0.1.1
+crystal: ">= 0.35, < 2"
+license: MIT
 
 authors:
   - Stefan Merettig <stefan-merettig@nuriaproject.org>
@@ -9,6 +11,6 @@ dependencies:
   cute:
     github: Papierkorb/cute
 
-crystal: 0.34.0
-
-license: MIT
+development_dependencies:
+  ameba:
+    github: crystal-ameba/ameba

--- a/spec/end_to_end/http_client_spec.cr
+++ b/spec/end_to_end/http_client_spec.cr
@@ -25,7 +25,7 @@ describe "HTTP client end-to-end test" do
       http_client = HTTP::Client.new("localhost", HTTP_PORT)
 
       client = JsonRpc::HttpClient.new(http_client)
-      client_response = client.call(JsonRpc::Response(String), "C2S", ["Konnichiwa"])
+      client_response = client.call(String, "C2S", ["Konnichiwa"])
       waiter.send nil
     end
 

--- a/spec/end_to_end/http_client_spec.cr
+++ b/spec/end_to_end/http_client_spec.cr
@@ -12,7 +12,7 @@ describe "HTTP client end-to-end test" do
       raw = ctx.request.body.not_nil!.gets_to_end
       server_request = raw
 
-      req = JsonRpc::Request(Array(String)).from_json raw
+      req = JsonRpc::Request.from_json raw
       ctx.response.print req.respond(raw).to_json
     end
 

--- a/spec/end_to_end/http_client_spec.cr
+++ b/spec/end_to_end/http_client_spec.cr
@@ -8,21 +8,17 @@ describe "HTTP client end-to-end test" do
     client_response = nil
     server_request = nil
     waiter = Channel(Nil).new
+    server = HTTP::Server.new do |ctx|
+      raw = ctx.request.body.not_nil!.gets_to_end
+      server_request = raw
+
+      req = JsonRpc::Request(Array(String)).from_json raw
+      ctx.response.print req.respond(raw).to_json
+    end
 
     spawn do # Server
-      server = nil
-      server = HTTP::Server.new("localhost", HTTP_PORT) do |ctx|
-        raw = ctx.request.body.not_nil!.gets_to_end
-        server_request = raw
-
-        req = JsonRpc::Request(Array(String)).from_json raw
-        ctx.response.print req.respond(raw).to_json
-
-        server.not_nil!.close
-      end
-
-      server.not_nil!.listen
-      waiter.send nil
+      server.bind_tcp HTTP_PORT
+      server.listen
     end
 
     spawn do # Client
@@ -34,9 +30,10 @@ describe "HTTP client end-to-end test" do
     end
 
     # Wait ...
-    2.times{ waiter.receive }
+    waiter.receive
 
     server_request.should_not eq nil
     server_request.should eq client_response
+    server.not_nil!.close
   end
 end

--- a/spec/end_to_end/http_client_spec.cr
+++ b/spec/end_to_end/http_client_spec.cr
@@ -25,7 +25,7 @@ describe "HTTP client end-to-end test" do
       http_client = HTTP::Client.new("localhost", HTTP_PORT)
 
       client = JsonRpc::HttpClient.new(http_client)
-      client_response = client.call(JsonRpc::Response(String), "C2S", [ "Konnichiwa" ])
+      client_response = client.call(JsonRpc::Response(String), "C2S", ["Konnichiwa"])
       waiter.send nil
     end
 

--- a/spec/end_to_end/tcp_spec.cr
+++ b/spec/end_to_end/tcp_spec.cr
@@ -16,29 +16,27 @@ describe "TCP end-to-end test" do
       tcp_server.close
 
       client = JsonRpc::TcpClient.new(tcp_socket)
-      client.handler = ProcHandler.new do |client, request, raw|
+      client.handler = ProcHandler.new do |_klient, _request, raw|
         client_to_server = raw
-        raw
       end
 
-      server_response = client.call(JsonRpc::Response(String), "S2C", [ "Hola" ])
+      server_response = client.call(JsonRpc::Response(String), "S2C", ["Hola"])
       waiter.send nil
     end
 
     spawn do # Client
       tcp_socket = TCPSocket.new("localhost", TCP_PORT)
       client = JsonRpc::TcpClient.new(tcp_socket)
-      client.handler = ProcHandler.new do |client, request, raw|
+      client.handler = ProcHandler.new do |_klient, _request, raw|
         server_to_client = raw
-        raw
       end
 
-      client_response = client.call(JsonRpc::Response(String), "C2S", [ "Hola" ])
+      client_response = client.call(JsonRpc::Response(String), "C2S", ["Hola"])
       waiter.send nil
     end
 
     # Wait ...
-    2.times{ waiter.receive }
+    2.times { waiter.receive }
 
     client_to_server.should_not eq nil
     server_to_client.should_not eq nil

--- a/spec/end_to_end/tcp_spec.cr
+++ b/spec/end_to_end/tcp_spec.cr
@@ -20,7 +20,7 @@ describe "TCP end-to-end test" do
         client_to_server = raw
       end
 
-      server_response = client.call(JsonRpc::Response(String), "S2C", ["Hola"])
+      server_response = client.call(String, "S2C", ["Hola"])
       waiter.send nil
     end
 
@@ -31,7 +31,7 @@ describe "TCP end-to-end test" do
         server_to_client = raw
       end
 
-      client_response = client.call(JsonRpc::Response(String), "C2S", ["Hola"])
+      client_response = client.call(String, "C2S", ["Hola"])
       waiter.send nil
     end
 

--- a/spec/end_to_end/websocket_spec.cr
+++ b/spec/end_to_end/websocket_spec.cr
@@ -1,0 +1,27 @@
+require "http/web_socket"
+
+require "../spec_helper"
+
+describe "Websocket client end-to-end test" do
+  it "works" do
+    server_request = nil
+
+    # Set up websockets on a blocking bidirectional IO
+    client_ws, server_ws = mock_websockets
+
+    server_ws.on_message do |m|
+      server_request = m
+      req = JsonRpc::Request.from_json m
+      server_ws.send req.respond(m).to_json
+    end
+
+    spawn { server_ws.run }
+
+    client = JsonRpc::WebSocketClient.new(client_ws, "/json-rpc")
+    client_response = client.call(String, "C2S", ["Konnichiwa"])
+
+    server_request.should_not eq nil
+    server_request.should eq client_response
+    server_ws.close
+  end
+end

--- a/spec/json_rpc/client_spec.cr
+++ b/spec/json_rpc/client_spec.cr
@@ -18,7 +18,7 @@ describe JsonRpc::Client do
       end
 
       Fiber.yield
-      io.sent.should eq [JsonRpc::Request(String).new(1i64, "foo", "bar").to_json, "\n"]
+      io.sent.should eq [JsonRpc::Request.new(1i64, "foo", "bar").to_json, "\n"]
       subject.process_document %<{ "id": 1, "result": "bar" }>
     end
 
@@ -36,8 +36,8 @@ describe JsonRpc::Client do
       subject.process_document %<{ "id": 2, "result": "tada" }>
 
       io.sent.should eq [
-        JsonRpc::Request(String).new(1i64, "foo", "bar").to_json, "\n",
-        JsonRpc::Request(String).new(2i64, "one", "two").to_json, "\n",
+        JsonRpc::Request.new(1i64, "foo", "bar").to_json, "\n",
+        JsonRpc::Request.new(2i64, "one", "two").to_json, "\n",
       ]
     end
 
@@ -54,7 +54,7 @@ describe JsonRpc::Client do
 
       Fiber.yield
 
-      io.sent.should eq [JsonRpc::Request(String).new(1i64, "foo", "bar").to_json, "\n"]
+      io.sent.should eq [JsonRpc::Request.new(1i64, "foo", "bar").to_json, "\n"]
       subject.process_document %<{ "id": 1, "result": "Okay" }>
       ch.receive
       result.should eq "Okay"
@@ -115,7 +115,7 @@ describe JsonRpc::Client do
       io, subject = create_client
 
       subject.notify "foo", "bar"
-      io.sent.should eq [JsonRpc::Request(String).new(nil, "foo", "bar").to_json, "\n"]
+      io.sent.should eq [JsonRpc::Request.new(nil, "foo", "bar").to_json, "\n"]
     end
   end
 

--- a/spec/json_rpc/client_spec.cr
+++ b/spec/json_rpc/client_spec.cr
@@ -1,11 +1,11 @@
 require "../spec_helper"
 
 private def create_client
-  io = TestIo.new([ ] of Bytes)
+  io = TestIo.new([] of Bytes)
   streamer = JsonRpc::DocumentStream.new(io)
   client = JsonRpc::StreamClient.new(streamer, "TEST", run: false)
 
-  { io, client }
+  {io, client}
 end
 
 describe JsonRpc::Client do
@@ -18,7 +18,7 @@ describe JsonRpc::Client do
       end
 
       Fiber.yield
-      io.sent.should eq [ JsonRpc::Request(String).new(1i64, "foo", "bar").to_json, "\n" ]
+      io.sent.should eq [JsonRpc::Request(String).new(1i64, "foo", "bar").to_json, "\n"]
       subject.process_document %<{ "id": 1, "result": "bar" }>
     end
 
@@ -55,7 +55,7 @@ describe JsonRpc::Client do
 
       Fiber.yield
 
-      io.sent.should eq [ JsonRpc::Request(String).new(1i64, "foo", "bar").to_json, "\n" ]
+      io.sent.should eq [JsonRpc::Request(String).new(1i64, "foo", "bar").to_json, "\n"]
       subject.process_document %<{ "id": 1, "result": "Okay" }>
       ch.receive
       result.should eq "Okay"
@@ -65,7 +65,7 @@ describe JsonRpc::Client do
       result = nil
       error = nil
 
-      io, subject = create_client
+      _io, subject = create_client
       ch = Channel(Nil).new
       spawn do
         begin
@@ -92,7 +92,7 @@ describe JsonRpc::Client do
 
   describe "#close" do
     it "emits connection_lost" do
-      io, subject = create_client
+      _io, subject = create_client
 
       conn_lost = Cute.spy subject, connection_lost()
       subject.close
@@ -101,7 +101,7 @@ describe JsonRpc::Client do
     end
 
     it "doesn't double-close" do
-      io, subject = create_client
+      _io, subject = create_client
 
       conn_lost = Cute.spy subject, connection_lost()
       subject.close
@@ -116,7 +116,7 @@ describe JsonRpc::Client do
       io, subject = create_client
 
       subject.notify "foo", "bar"
-      io.sent.should eq [ JsonRpc::Request(String).new(nil, "foo", "bar").to_json, "\n" ]
+      io.sent.should eq [JsonRpc::Request(String).new(nil, "foo", "bar").to_json, "\n"]
     end
   end
 
@@ -124,7 +124,7 @@ describe JsonRpc::Client do
     it "sends the message in verbatim" do
       io, subject = create_client
       subject.notify_raw "Whazzup?!"
-      io.sent.should eq [ "Whazzup?!", "\n" ]
+      io.sent.should eq ["Whazzup?!", "\n"]
     end
   end
 
@@ -153,7 +153,7 @@ describe JsonRpc::Client do
         raise "Crystal bug" if my_request.nil?
 
         my_request.method.should eq "foo"
-        my_request.params.should eq JSON::Any.new([ JSON::Any.new(123i64) ])
+        my_request.params.should eq JSON::Any.new([JSON::Any.new(123i64)])
         my_request.id.should eq nil
 
         io.sent.size.should eq 0
@@ -184,41 +184,41 @@ describe JsonRpc::Client do
         raise "Crystal bug" if my_request.nil?
 
         my_request.method.should eq "foo"
-        my_request.params.should eq JSON::Any.new([ JSON::Any.new(123i64) ])
+        my_request.params.should eq JSON::Any.new([JSON::Any.new(123i64)])
         my_request.id.should eq 1i64
 
-        io.sent.should eq [ JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n" ]
+        io.sent.should eq [JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n"]
       end
 
       it "calls the handler and sends the custom result" do
         io, client = create_client
-        client.handler = ProcHandler.new do |klient, req, raw_data|
+        client.handler = ProcHandler.new do |_klient, _req, _raw_data|
           JsonRpc::Response(String).new(1i64, "Okay!", nil)
         end
 
         request_str = %<{ "id": 1, "method": "foo", "params": [123] }>
         client.process_document request_str
 
-        io.sent.should eq [ JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n" ]
+        io.sent.should eq [JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n"]
       end
 
       it "calls the handler and sends an error" do
         io, client = create_client
-        client.handler = ProcHandler.new do |klient, req, raw_data|
+        client.handler = ProcHandler.new do |_klient, _req, _raw_data|
           raise JsonRpc::LocalCallError.new("Private", 123, "Public", 456i64)
         end
 
         request_str = %<{ "id": 1, "method": "foo", "params": [123] }>
         client.process_document request_str
 
-        io.sent.should eq [ JsonRpc::Response(Nil).new(1i64, nil, JSON::Any.new [ JSON::Any.new(123i64), JSON::Any.new("Public"), JSON::Any.new(456i64) ]).to_json, "\n" ]
+        io.sent.should eq [JsonRpc::Response(Nil).new(1i64, nil, JSON::Any.new [JSON::Any.new(123i64), JSON::Any.new("Public"), JSON::Any.new(456i64)]).to_json, "\n"]
       end
 
       it "handles a DelayedResponse" do
         io, client = create_client
         waiter = Channel(Nil).new
 
-        client.handler = ProcHandler.new do |klient, req, raw_data|
+        client.handler = ProcHandler.new do |klient, req, _raw_data|
           delayed = req.respond_later(klient)
 
           spawn do
@@ -235,7 +235,7 @@ describe JsonRpc::Client do
         io.sent.empty?.should eq true
         waiter.send nil
 
-        io.sent.should eq [ JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n" ]
+        io.sent.should eq [JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n"]
       end
     end
   end
@@ -246,7 +246,7 @@ describe JsonRpc::Client do
       flood_spy = Cute.spy subject, flood_protection_triggered()
 
       subject.flood_messages = 9
-      10.times{ subject.process_document %<{ "id": null, "method": "foo", "params": [] }> }
+      10.times { subject.process_document %<{ "id": null, "method": "foo", "params": [] }> }
       flood_spy.size.should eq 1
     end
 
@@ -255,7 +255,7 @@ describe JsonRpc::Client do
       flood_spy = Cute.spy subject, flood_protection_triggered()
 
       subject.flood_messages = 9
-      9.times{ subject.process_document %<{ "id": null, "method": "foo", "params": [] }> }
+      9.times { subject.process_document %<{ "id": null, "method": "foo", "params": [] }> }
       flood_spy.size.should eq 0
     end
   end

--- a/spec/json_rpc/client_spec.cr
+++ b/spec/json_rpc/client_spec.cr
@@ -14,7 +14,7 @@ describe JsonRpc::Client do
       io, subject = create_client
 
       spawn do
-        subject.call JsonRpc::Response(String), "foo", "bar"
+        subject.call String, "foo", "bar"
       end
 
       Fiber.yield
@@ -26,13 +26,12 @@ describe JsonRpc::Client do
       io, subject = create_client
 
       spawn do
-        subject.call JsonRpc::Response(String), "foo", "bar"
-        subject.call JsonRpc::Response(String), "one", "two"
+        subject.call String, "foo", "bar"
+        subject.call String, "one", "two"
       end
 
       Fiber.yield
       subject.process_document %<{ "id": 1, "result": "bar" }>
-
       Fiber.yield
       subject.process_document %<{ "id": 2, "result": "tada" }>
 
@@ -49,7 +48,7 @@ describe JsonRpc::Client do
       ch = Channel(Nil).new
 
       spawn do
-        result = subject.call JsonRpc::Response(String), "foo", "bar"
+        result = subject.call String, "foo", "bar"
         ch.send nil
       end
 
@@ -69,7 +68,7 @@ describe JsonRpc::Client do
       ch = Channel(Nil).new
       spawn do
         begin
-          result = subject.call JsonRpc::Response(String), "foo", "bar"
+          result = subject.call String, "foo", "bar"
         rescue e : JsonRpc::RemoteCallError
           error = e
         end
@@ -187,19 +186,19 @@ describe JsonRpc::Client do
         my_request.params.should eq JSON::Any.new([JSON::Any.new(123i64)])
         my_request.id.should eq 1i64
 
-        io.sent.should eq [JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n"]
+        io.sent.should eq [JsonRpc::Response.new(1i64, "Okay!", nil).to_json, "\n"]
       end
 
       it "calls the handler and sends the custom result" do
         io, client = create_client
         client.handler = ProcHandler.new do |_klient, _req, _raw_data|
-          JsonRpc::Response(String).new(1i64, "Okay!", nil)
+          JsonRpc::Response.new(1i64, "Okay!", nil)
         end
 
         request_str = %<{ "id": 1, "method": "foo", "params": [123] }>
         client.process_document request_str
 
-        io.sent.should eq [JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n"]
+        io.sent.should eq [JsonRpc::Response.new(1i64, "Okay!", nil).to_json, "\n"]
       end
 
       it "calls the handler and sends an error" do
@@ -211,7 +210,7 @@ describe JsonRpc::Client do
         request_str = %<{ "id": 1, "method": "foo", "params": [123] }>
         client.process_document request_str
 
-        io.sent.should eq [JsonRpc::Response(Nil).new(1i64, nil, JSON::Any.new [JSON::Any.new(123i64), JSON::Any.new("Public"), JSON::Any.new(456i64)]).to_json, "\n"]
+        io.sent.should eq [JsonRpc::Response.new(1i64, nil, JSON::Any.new [JSON::Any.new(123i64), JSON::Any.new("Public"), JSON::Any.new(456i64)]).to_json, "\n"]
       end
 
       it "handles a DelayedResponse" do
@@ -235,7 +234,7 @@ describe JsonRpc::Client do
         io.sent.empty?.should eq true
         waiter.send nil
 
-        io.sent.should eq [JsonRpc::Response(String).new(1i64, "Okay!", nil).to_json, "\n"]
+        io.sent.should eq [JsonRpc::Response.new(1i64, "Okay!", nil).to_json, "\n"]
       end
     end
   end

--- a/spec/json_rpc/document_stream_spec.cr
+++ b/spec/json_rpc/document_stream_spec.cr
@@ -74,7 +74,7 @@ describe JsonRpc::DocumentStream do
     end
 
     it "reads multiple documents in same chunk" do
-      io = TestIo.new([ %<{"foo":"bar"}{"one": 2}> ])
+      io = TestIo.new([%<{"foo":"bar"}{"one": 2}>])
       stream = JsonRpc::DocumentStream.new(io)
 
       stream.read_document.should eq %<{"foo":"bar"}>
@@ -90,7 +90,7 @@ describe JsonRpc::DocumentStream do
     end
 
     it "raises if device was closed before document" do
-      io = TestIo.new([ ] of Bytes)
+      io = TestIo.new([] of Bytes)
       stream = JsonRpc::DocumentStream.new(io)
 
       expect_raises(JsonRpc::DocumentStream::DeviceClosedError) do
@@ -99,7 +99,7 @@ describe JsonRpc::DocumentStream do
     end
 
     it "raises if device was closed mid-document" do
-      io = TestIo.new([ %<{ "foo": "ba> ])
+      io = TestIo.new([%<{ "foo": "ba>])
       stream = JsonRpc::DocumentStream.new(io)
 
       expect_raises(JsonRpc::DocumentStream::DeviceClosedError) do

--- a/spec/json_rpc/http_client_spec.cr
+++ b/spec/json_rpc/http_client_spec.cr
@@ -25,7 +25,7 @@ describe JsonRpc::HttpClient do
       client = JsonRpc::HttpClient.new mock, "/json-rpc"
 
       mock.add_response 200, %<{"id":1, "result":"Okay"}>
-      result = client.call JsonRpc::Response(String), "foo"
+      result = client.call String, "foo"
       result.should eq "Okay"
 
       request = mock.requests.shift
@@ -42,7 +42,7 @@ describe JsonRpc::HttpClient do
         mock.add_response 404, %<{"id":1, "result":"Okay"}>
 
         expect_raises(JsonRpc::ConnectionError) do
-          client.call JsonRpc::Response(String), "foo"
+          client.call String, "foo"
         end
       end
     end

--- a/spec/json_rpc/http_client_spec.cr
+++ b/spec/json_rpc/http_client_spec.cr
@@ -31,7 +31,7 @@ describe JsonRpc::HttpClient do
       request = mock.requests.shift
       request.method.should eq "POST"
       request.path.should eq "/json-rpc"
-      request.body.try(&.gets_to_end).should eq JsonRpc::Request(String).new(1i64, "foo", nil).to_json
+      request.body.try(&.gets_to_end).should eq JsonRpc::Request.new(1i64, "foo", nil).to_json
     end
 
     context "on non-200 response code" do

--- a/spec/json_rpc/message_spec.cr
+++ b/spec/json_rpc/message_spec.cr
@@ -4,7 +4,7 @@ describe JsonRpc::Message do
   describe "#response?" do
     context "for a request" do
       it "returns false" do
-        JsonRpc::Message.from_json(%<{"id": 1, "method": \"foo\", "params": []}>).response?.should eq false
+        JsonRpc::Message.from_json(%<{"id": 1, "method": "foo", "params": []}>).response?.should eq false
       end
     end
 
@@ -16,7 +16,7 @@ describe JsonRpc::Message do
 
     context "for a notification" do
       it "returns false" do
-        JsonRpc::Message.from_json(%<{"id": null, "method": \"foo\", "params": []}>).response?.should eq false
+        JsonRpc::Message.from_json(%<{"id": null, "method": "foo", "params": []}>).response?.should eq false
       end
     end
   end

--- a/spec/json_rpc/stream_client_spec.cr
+++ b/spec/json_rpc/stream_client_spec.cr
@@ -28,13 +28,13 @@ describe JsonRpc::StreamClient do
     it "sends a message out" do
       client = create_client
       client.send_message 123, "FooBar"
-      client.stream.io.as(TestIo).sent.should eq [ "FooBar", "\n" ]
+      client.stream.io.as(TestIo).sent.should eq ["FooBar", "\n"]
     end
   end
 
   describe "#recv_message" do
     it "receives a message asynchronously" do
-      inputs = [ %<{"id": 1, "result": "One"}>, %<{"id": 2, "result": "Two"}> ]
+      inputs = [%<{"id": 1, "result": "One"}>, %<{"id": 2, "result": "Two"}>]
       client = create_client(inputs)
 
       client.fatal_remote_error.on do |error|
@@ -42,24 +42,24 @@ describe JsonRpc::StreamClient do
         abort "Unexpected fatal_remote_error"
       end
 
-      spawn{ client.read_once }
+      spawn { client.read_once }
       client.recv_message(1i64).should eq inputs[0]
 
-      spawn{ client.read_once }
+      spawn { client.read_once }
       client.recv_message(2i64).should eq inputs[1]
     end
   end
 
   describe "#read_once" do
     it "handles an incoming response" do
-      client = create_client([ %<{"id": 1, "result": "One"}> ])
+      client = create_client([%<{"id": 1, "result": "One"}>])
 
-      spawn{ client.read_once }
+      spawn { client.read_once }
       client.recv_message(1i64).should eq %<{"id": 1, "result": "One"}>
     end
 
     it "handles an incoming invocation" do
-      client = create_client([ %<{"id": 2, "method": "foo", "params": "yada"}> ])
+      client = create_client([%<{"id": 2, "method": "foo", "params": "yada"}>])
       raw = nil
 
       client.handler = ProcHandler.new do |klient, _, raw_data|
@@ -87,7 +87,7 @@ describe JsonRpc::StreamClient do
 
     context "on unexpected response" do
       it "emits a fatal_remote_error" do
-        client = create_client([ %<{"id": 1, "result": "One"}> ])
+        client = create_client([%<{"id": 1, "result": "One"}>])
 
         client.fatal_remote_error.disconnect
         error_spy = Cute.spy client, fatal_remote_error(raw : String?, error : Exception)

--- a/spec/json_rpc/websocket_client_spec.cr
+++ b/spec/json_rpc/websocket_client_spec.cr
@@ -1,0 +1,46 @@
+require "../spec_helper"
+
+class WebSocketServer
+  getter socket : HTTP::WebSocket
+  getter responses = [] of String
+  getter requests = [] of String
+
+  def initialize(@socket)
+    socket.on_message do |message|
+      requests << message
+      socket.send(responses.shift)
+    end
+  end
+
+  def add_response(arg)
+    responses << arg
+  end
+end
+
+describe JsonRpc::WebSocketClient do
+  describe "#call" do
+    it "sends a request and receives a response" do
+      client_ws, server_ws = mock_websockets
+
+      server = WebSocketServer.new(server_ws)
+      server.add_response %({"id":1, "result":"Okay"})
+
+      spawn { server_ws.run }
+      Fiber.yield
+
+      client = JsonRpc::WebSocketClient.new client_ws, "/json-rpc"
+      Fiber.yield
+
+      result = client.call String, "foo"
+      Fiber.yield
+
+      result.should eq "Okay"
+
+      request = server.requests.first?
+
+      request.should eq JsonRpc::Request.new(1i64, "foo", nil).to_json
+
+      server_ws.close
+    end
+  end
+end

--- a/spec/proc_handler.cr
+++ b/spec/proc_handler.cr
@@ -1,7 +1,7 @@
 class ProcHandler
   include JsonRpc::Handler
 
-  def initialize(&@proc : JsonRpc::Client, JsonRpc::Request(JSON::Any), String -> JsonRpc::Response(String) | JsonRpc::DelayedResponse | String)
+  def initialize(&@proc : JsonRpc::Client, JsonRpc::Request(JSON::Any), String -> JsonRpc::Response | JsonRpc::DelayedResponse | String)
   end
 
   def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request(JSON::Any), raw : String)

--- a/spec/proc_handler.cr
+++ b/spec/proc_handler.cr
@@ -1,10 +1,10 @@
 class ProcHandler
   include JsonRpc::Handler
 
-  def initialize(&@proc : JsonRpc::Client, JsonRpc::Request(JSON::Any), String -> JsonRpc::Response | JsonRpc::DelayedResponse | String)
+  def initialize(&@proc : JsonRpc::Client, JsonRpc::Request, String -> JsonRpc::Response | JsonRpc::DelayedResponse | String)
   end
 
-  def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request(JSON::Any), raw : String)
+  def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request, raw : String)
     @proc.call client, request, raw
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,3 +4,9 @@ require "cute/spec"
 require "../src/json_rpc"
 require "./test_io"
 require "./proc_handler"
+
+# Set up websockets on a blocking bidirectional IO
+def mock_websockets
+  io_l, io_r = IO::Stapled.pipe
+  ({HTTP::WebSocket.new(io_l), HTTP::WebSocket.new(io_r)})
+end

--- a/spec/test_io.cr
+++ b/spec/test_io.cr
@@ -1,5 +1,4 @@
 class TestIo < IO
-
   getter sent = [] of String
 
   def initialize(choreography : Array(String))
@@ -13,7 +12,7 @@ class TestIo < IO
     current = @choreography.first?
     return 0 if current.nil?
 
-    count = { buffer.size, current.size }.min
+    count = {buffer.size, current.size}.min
     buffer.copy_from current[0, count]
 
     if (current + count).size < 1

--- a/spec/test_io.cr
+++ b/spec/test_io.cr
@@ -1,5 +1,4 @@
-class TestIo
-  include IO
+class TestIo < IO
 
   getter sent = [] of String
 
@@ -26,7 +25,7 @@ class TestIo
     count
   end
 
-  def write(buffer : Bytes)
+  def write(buffer : Bytes) : Nil
     @sent << String.new(buffer)
     nil
   end

--- a/src/json_rpc/client.cr
+++ b/src/json_rpc/client.cr
@@ -151,7 +151,7 @@ module JsonRpc
     # Called by `Client` implementations to invoke a local method.
     def invoke_from_remote(request : Request(JSON::Any), raw : String) : Nil
       if @async_call
-        spawn{ process_local_invocation request, raw }
+        spawn { process_local_invocation request, raw }
       else
         process_local_invocation request, raw
       end
@@ -173,14 +173,12 @@ module JsonRpc
       result = @handler.handle_rpc_call(self, request, raw)
 
       case result
-      when Response then result
+      when Response        then result
       when DelayedResponse then nil
-      else request.respond(result)
+      else                      request.respond(result)
       end
-
     rescue err : LocalCallError
       request.respond(err)
-
     rescue err
       fatal_local_error.emit request, raw, err
       request.respond(LocalCallError.new(-32603, "Internal Server Error"))

--- a/src/json_rpc/client.cr
+++ b/src/json_rpc/client.cr
@@ -48,7 +48,7 @@ module JsonRpc
     # Emitted when the remote end has called a local method, but the handler
     # (Set through `#on_call`) raised an exception which is not a
     # `LocalCallError`.
-    Cute.signal fatal_local_error(request : Request(JSON::Any), raw : String, error : Exception)
+    Cute.signal fatal_local_error(request : Request, raw : String, error : Exception)
 
     # Emitted when the remote end sent something the implementation was not able
     # to handle.  Usually happens when receiving garbage.
@@ -106,7 +106,7 @@ module JsonRpc
     # `RemoteCallError` is **returned**. Otherwise, the **nilable** result is
     # returned.
     def call?(result_type, method : String, params = nil)
-      request = Request(typeof(params)).new(next_id, method, params)
+      request = Request.new(next_id, method, params)
       _send_message(request.id, request.to_json)
 
       message_data = recv_message(request.id)
@@ -128,20 +128,20 @@ module JsonRpc
 
     # Sends a notification to *method* with *params* to the remote end.
     def notify(method : String, params = nil)
-      request = Request(typeof(params)).new(nil, method, params)
+      request = Request.new(nil, method, params)
       _send_message(nil, request.to_json)
     end
 
     # Sends a notification to the remote end, that is already serialized.
     # Useful to send a notification to many clients in bulk.
     #
-    # Use `Request(T)#to_json` for easy construction of a message.
+    # Use `Request#to_json` for easy construction of a message.
     def notify_raw(message : String)
       _send_message(nil, message)
     end
 
     # Called by `Client` implementations to invoke a local method.
-    def invoke_from_remote(request : Request(JSON::Any), raw : String) : Nil
+    def invoke_from_remote(request : Request, raw : String) : Nil
       if @async_call
         spawn { process_local_invocation request, raw }
       else

--- a/src/json_rpc/client.cr
+++ b/src/json_rpc/client.cr
@@ -31,7 +31,7 @@ module JsonRpc
     # Set to `nil` to disable the flood-protection.
     property flood_messages : Int32? = 6000
 
-    @flood_time_end : Time = Time.now
+    @flood_time_end : Time = Time.local
     @flood_count : Int32 = 0
 
     # Total count of messages sent.
@@ -202,7 +202,7 @@ module JsonRpc
       flood_messages = @flood_messages
       return true if flood_messages.nil?
 
-      now = Time.now
+      now = Time.local
       if now > @flood_time_end
         # Last message was received a long time ago, reset flood protection.
         @flood_time_end = now + @flood_time_span

--- a/src/json_rpc/delayed_response.cr
+++ b/src/json_rpc/delayed_response.cr
@@ -15,17 +15,17 @@ module JsonRpc
 
     # Sends an error response.
     def respond(failure : LocalCallError)
-      send Response(Nil).new(@id, nil, failure.object)
+      send Response.new(@id, nil, failure.object)
     end
 
     # Sends an error response.
     def error(code : Int32, message : String, data : JSON::Any? = nil)
-      send Response(Nil).new(@id, nil, LocalCallError.error_object(code, public_message, data))
+      send Response.new(@id, nil, LocalCallError.error_object(code, public_message, data))
     end
 
     # Sends a successful response based on *result*.
     def respond(result)
-      send Response(typeof(result)).new(@id, result, nil)
+      send Response.new(@id, result, nil)
     end
 
     # Sends a *response* to the backing `#client`.

--- a/src/json_rpc/document_stream.cr
+++ b/src/json_rpc/document_stream.cr
@@ -26,7 +26,7 @@ module JsonRpc
 
     @buffer_size : Int32 = 0
 
-    private getter buffer : Bytes { Bytes.new(BUFFER_SIZE) }
+    private getter buffer = Bytes.new(BUFFER_SIZE)
 
     # Constructs a reader with backing device *io*
     def initialize(@io : IO)

--- a/src/json_rpc/document_stream.cr
+++ b/src/json_rpc/document_stream.cr
@@ -58,7 +58,7 @@ module JsonRpc
           next_offset = 0
 
           while pos < @buffer_size
-            case buffer[pos].ord
+            case buffer[pos].unsafe_chr
             # Count brace.  Doesn't differentiate between curly and square ones.
             when '{', '['
               braces += 1 unless in_string

--- a/src/json_rpc/handler.cr
+++ b/src/json_rpc/handler.cr
@@ -8,7 +8,7 @@ module JsonRpc
     # Raising any other error will be caught in `Client#invoke_locally`.
     #
     # The default implementation always responds with an unknown method error.
-    def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request(JSON::Any), raw : String)
+    def handle_rpc_call(client : JsonRpc::Client, request : JsonRpc::Request, raw : String)
       request.respond LocalCallError.new(-32601, "Unknown method")
     end
   end

--- a/src/json_rpc/http_client.cr
+++ b/src/json_rpc/http_client.cr
@@ -7,12 +7,12 @@ module JsonRpc
   # To do authentication, configure the `HTTP::Client` you pass in as needed.
   #
   # An example for HTTP Basic auth:
-  # ```crystal
-  #   http_client = HTTP::Client.new("some.internal.server", 1234)
-  #   http_client.basic_auth("my-username", "the-password")
+  # ```
+  # http_client = HTTP::Client.new("some.internal.server", 1234)
+  # http_client.basic_auth("my-username", "the-password")
   #
-  #   rpc_client = JsonRpc::HttpClient.new(http_client)
-  #   # rpc_client will now use basic authentication for each request!
+  # rpc_client = JsonRpc::HttpClient.new(http_client)
+  # # rpc_client will now use basic authentication for each request!
   # ```
   class HttpClient < Client
     getter http_client : HTTP::Client

--- a/src/json_rpc/http_client.cr
+++ b/src/json_rpc/http_client.cr
@@ -43,7 +43,7 @@ module JsonRpc
       @buffer.delete id
     end
 
-    def remote_address
+    def remote_address : String
       "#{@http_client.host}:#{@http_client.port}#{@endpoint}"
     end
 

--- a/src/json_rpc/local_call_error.cr
+++ b/src/json_rpc/local_call_error.cr
@@ -33,9 +33,9 @@ module JsonRpc
 
     def self.error_object(code : Int32, public_message : String, data = nil)
       if data.nil?
-        ary = [ code.to_i64, public_message ] of JSON::Type
+        ary = [ JSON::Any.new(code.to_i64), JSON::Any.new(public_message) ]
       else
-        ary = [ code.to_i64, public_message, data ] of JSON::Type
+        ary = [ JSON::Any.new(code.to_i64), JSON::Any.new(public_message), JSON::Any.new(data) ]
       end
 
       JSON::Any.new(ary)

--- a/src/json_rpc/local_call_error.cr
+++ b/src/json_rpc/local_call_error.cr
@@ -33,9 +33,9 @@ module JsonRpc
 
     def self.error_object(code : Int32, public_message : String, data = nil)
       if data.nil?
-        ary = [ JSON::Any.new(code.to_i64), JSON::Any.new(public_message) ]
+        ary = [JSON::Any.new(code.to_i64), JSON::Any.new(public_message)]
       else
-        ary = [ JSON::Any.new(code.to_i64), JSON::Any.new(public_message), JSON::Any.new(data) ]
+        ary = [JSON::Any.new(code.to_i64), JSON::Any.new(public_message), JSON::Any.new(data)]
       end
 
       JSON::Any.new(ary)

--- a/src/json_rpc/message.cr
+++ b/src/json_rpc/message.cr
@@ -4,11 +4,11 @@ module JsonRpc
   class Message
     JSON.mapping({
       id: {
-        type: IdType,
+        type:    IdType,
         nilable: true,
       },
       method: {
-        type: String,
+        type:    String,
         nilable: true,
       },
     })

--- a/src/json_rpc/message.cr
+++ b/src/json_rpc/message.cr
@@ -1,20 +1,14 @@
+require "json"
+
 module JsonRpc
   # Used by `Client` implementations to guess if the received message is a
   # request or a response.
-  class Message
-    JSON.mapping({
-      id: {
-        type:    IdType,
-        nilable: true,
-      },
-      method: {
-        type:    String,
-        nilable: true,
-      },
-    })
+  struct Message
+    include JSON::Serializable
+    getter id : IdType?
+    getter method : String?
 
-    def response?
-      @method.nil?
-    end
+    @[JSON::Field(ignore: true)]
+    getter? response : Bool { method.nil? }
   end
 end

--- a/src/json_rpc/message_header.cr
+++ b/src/json_rpc/message_header.cr
@@ -1,0 +1,10 @@
+module JsonRpc
+  # Shared properties between `JsonRpc::Request(T)` and `JsonRpc::Response(T)`
+  module MessageHeader
+    # Would not be standard conform, but oh well
+    getter jsonrpc : String? = "2.0"
+
+    @[JSON::Field(emit_null: true)]
+    getter id : IdType?
+  end
+end

--- a/src/json_rpc/message_header.cr
+++ b/src/json_rpc/message_header.cr
@@ -1,5 +1,7 @@
+require "json"
+
 module JsonRpc
-  # Shared properties between `JsonRpc::Request(T)` and `JsonRpc::Response(T)`
+  # Shared properties between `JsonRpc::Request` and `JsonRpc::Response`
   module MessageHeader
     # Would not be standard conform, but oh well
     getter jsonrpc : String? = "2.0"

--- a/src/json_rpc/remote_call_error.cr
+++ b/src/json_rpc/remote_call_error.cr
@@ -14,8 +14,8 @@ module JsonRpc
       if ary = @object.as_a?
         (
           ary.size >= 2 &&
-          ary[0].raw.is_a?(Int64) &&
-          ary[1].raw.is_a?(String)
+            ary[0].raw.is_a?(Int64) &&
+            ary[1].raw.is_a?(String)
         )
       else
         false

--- a/src/json_rpc/remote_call_error.cr
+++ b/src/json_rpc/remote_call_error.cr
@@ -14,8 +14,8 @@ module JsonRpc
       if ary = @object.as_a?
         (
           ary.size >= 2 &&
-          ary[0].is_a?(Int64) &&
-          ary[1].is_a?(String)
+          ary[0].raw.is_a?(Int64) &&
+          ary[1].raw.is_a?(String)
         )
       else
         false

--- a/src/json_rpc/request.cr
+++ b/src/json_rpc/request.cr
@@ -17,17 +17,17 @@ module JsonRpc
 
     # Creates an error response.
     def respond(failure : LocalCallError)
-      Response(Nil).new(id, nil, failure.object)
+      Response.new(id, nil, failure.object)
     end
 
     # Creates an error response.
     def error(code : Int32, message : String, data : JSON::Any? = nil)
-      Response(Nil).new(id, nil, LocalCallError.error_object(code, public_message, data))
+      Response.new(id, nil, LocalCallError.error_object(code, public_message, data))
     end
 
     # Creates a successful response based on *result*.
     def respond(result)
-      Response(typeof(result)).new(id, result, nil)
+      Response.new(id, result, nil)
     end
 
     # Returns a `DelayedResponse`, bound to *client*.

--- a/src/json_rpc/request.cr
+++ b/src/json_rpc/request.cr
@@ -3,22 +3,22 @@ module JsonRpc
   class Request(T)
     JSON.mapping({
       jsonrpc: {
-        type: String,
+        type:    String,
         default: "2.0",
         nilable: true, # Would not be standard conform, but oh well
       },
       id: {
-        type: IdType,
-        nilable: true,
+        type:      IdType,
+        nilable:   true,
         emit_null: true,
       },
       method: {
         type: String,
       },
       params: {
-        type: T,
+        type:    T,
         nilable: true,
-      }
+      },
     })
 
     def initialize(@id, @method, @params)

--- a/src/json_rpc/request.cr
+++ b/src/json_rpc/request.cr
@@ -4,15 +4,20 @@ require "./message_header"
 
 module JsonRpc
   # Encapsulates a JSON-RPC request object
-  struct Request(T)
+  struct Request
     include JSON::Serializable
     include MessageHeader
 
     getter method : String
 
-    getter params : T?
+    @[JSON::Field(key: "params", converter: String::RawConverter)]
+    getter raw_params : String?
 
-    def initialize(@id, @method, @params)
+    @[JSON::Field(ignore: true)]
+    getter params : JSON::Any? { raw_params.try { |o| JSON.parse(o) } }
+
+    def initialize(@id, @method, params)
+      @raw_params = params.try &.to_json
     end
 
     # Creates an error response.

--- a/src/json_rpc/request.cr
+++ b/src/json_rpc/request.cr
@@ -1,43 +1,33 @@
+require "json"
+
+require "./message_header"
+
 module JsonRpc
   # Encapsulates a JSON-RPC request object
-  class Request(T)
-    JSON.mapping({
-      jsonrpc: {
-        type:    String,
-        default: "2.0",
-        nilable: true, # Would not be standard conform, but oh well
-      },
-      id: {
-        type:      IdType,
-        nilable:   true,
-        emit_null: true,
-      },
-      method: {
-        type: String,
-      },
-      params: {
-        type:    T,
-        nilable: true,
-      },
-    })
+  struct Request(T)
+    include JSON::Serializable
+    include MessageHeader
+
+    getter method : String
+
+    getter params : T?
 
     def initialize(@id, @method, @params)
-      @jsonrpc = "2.0"
     end
 
     # Creates an error response.
     def respond(failure : LocalCallError)
-      Response(Nil).new(@id, nil, failure.object)
+      Response(Nil).new(id, nil, failure.object)
     end
 
     # Creates an error response.
     def error(code : Int32, message : String, data : JSON::Any? = nil)
-      Response(Nil).new(@id, nil, LocalCallError.error_object(code, public_message, data))
+      Response(Nil).new(id, nil, LocalCallError.error_object(code, public_message, data))
     end
 
     # Creates a successful response based on *result*.
     def respond(result)
-      Response(typeof(result)).new(@id, result, nil)
+      Response(typeof(result)).new(id, result, nil)
     end
 
     # Returns a `DelayedResponse`, bound to *client*.
@@ -45,7 +35,7 @@ module JsonRpc
     # Return the result of this method from your `Handler#handle_rpc_call`, and
     # keep a handle to it somewhere to respond later.
     def respond_later(client : Client) : DelayedResponse
-      DelayedResponse.new(@id, client)
+      DelayedResponse.new(id, client)
     end
   end
 end

--- a/src/json_rpc/response.cr
+++ b/src/json_rpc/response.cr
@@ -3,7 +3,7 @@ require "json"
 require "./message_header"
 
 module JsonRpc
-  private abstract struct ResponseBase(T)
+  private abstract struct ResponseBase
     include JSON::Serializable
     include MessageHeader
 
@@ -15,15 +15,17 @@ module JsonRpc
 
   # Encapsulates a JSON-RPC invocation response.  See `Request#respond` to
   # create a response conveniently.
-  struct Response(T) < ResponseBase(T)
-    getter result : T?
+  struct Response < ResponseBase
+    @[JSON::Field(converter: String::RawConverter)]
+    getter result : String?
 
-    def initialize(@id, @result, @error)
+    def initialize(@id, result, @error)
+      @result = result.try &.to_json
       super(@id, @error)
     end
   end
 
-  # `JsonRpc::Response(T)` with no `result` key
-  struct EmptyResponse < ResponseBase(Nil)
+  # `JsonRpc::Response` with no `result` key
+  struct EmptyResponse < ResponseBase
   end
 end

--- a/src/json_rpc/response.cr
+++ b/src/json_rpc/response.cr
@@ -1,59 +1,29 @@
-module JsonRpc
-  # Encapsulates a JSON-RPC invocation response.  See `Request#respond` to
-  # create a response conveniently.
-  #
-  # If you're looking to receive a response with no result, see `EmptyResponse`.
-  class Response(T)
-    JSON.mapping({
-      jsonrpc: {
-        type:    String,
-        default: "2.0",
-        nilable: true, # Would not be standard conform, but oh well
-      },
-      id: {
-        type:      IdType,
-        nilable:   true,
-        emit_null: true,
-      },
-      result: {
-        type:      T,
-        nilable:   true,
-        emit_null: false,
-      },
-      error: {
-        type:      JSON::Any,
-        nilable:   true,
-        emit_null: false,
-      },
-    })
+require "json"
 
-    def initialize(@id, @result, @error)
-      @jsonrpc = "2.0"
+require "./message_header"
+
+module JsonRpc
+  private abstract struct ResponseBase(T)
+    include JSON::Serializable
+    include MessageHeader
+
+    getter error : JSON::Any?
+
+    def initialize(@id, @error)
     end
   end
 
-  # Encapsulates an *empty* JSON-RPC invocation response.
-  class EmptyResponse
-    JSON.mapping({
-      jsonrpc: {
-        type:    String,
-        default: "2.0",
-        nilable: true, # Would not be standard conform, but oh well
-      },
-      id: {
-        type:      IdType,
-        nilable:   true,
-        emit_null: true,
-      },
-      error: {
-        type:      JSON::Any,
-        nilable:   true,
-        emit_null: false,
-      },
-    })
+  # Encapsulates a JSON-RPC invocation response.  See `Request#respond` to
+  # create a response conveniently.
+  struct Response(T) < ResponseBase(T)
+    getter result : T?
 
-    def initialize(@id, @error = nil)
-      @jsonrpc = "2.0"
+    def initialize(@id, @result, @error)
+      super(@id, @error)
     end
+  end
+
+  # `JsonRpc::Response(T)` with no `result` key
+  struct EmptyResponse < ResponseBase(Nil)
   end
 end

--- a/src/json_rpc/response.cr
+++ b/src/json_rpc/response.cr
@@ -6,23 +6,23 @@ module JsonRpc
   class Response(T)
     JSON.mapping({
       jsonrpc: {
-        type: String,
+        type:    String,
         default: "2.0",
         nilable: true, # Would not be standard conform, but oh well
       },
       id: {
-        type: IdType,
-        nilable: true,
+        type:      IdType,
+        nilable:   true,
         emit_null: true,
       },
       result: {
-        type: T,
-        nilable: true,
+        type:      T,
+        nilable:   true,
         emit_null: false,
       },
       error: {
-        type: JSON::Any,
-        nilable: true,
+        type:      JSON::Any,
+        nilable:   true,
         emit_null: false,
       },
     })
@@ -36,18 +36,18 @@ module JsonRpc
   class EmptyResponse
     JSON.mapping({
       jsonrpc: {
-        type: String,
+        type:    String,
         default: "2.0",
         nilable: true, # Would not be standard conform, but oh well
       },
       id: {
-        type: IdType,
-        nilable: true,
+        type:      IdType,
+        nilable:   true,
         emit_null: true,
       },
       error: {
-        type: JSON::Any,
-        nilable: true,
+        type:      JSON::Any,
+        nilable:   true,
         emit_null: false,
       },
     })

--- a/src/json_rpc/stream.cr
+++ b/src/json_rpc/stream.cr
@@ -1,0 +1,43 @@
+require "./message"
+
+module JsonRpc
+  # Helpers for multiplexing streamed clients
+  module Stream
+    protected getter channels : Hash(IdType, Channel(String)) { {} of IdType => Channel(String) }
+
+    # Interface for `JsonRpc::Client`
+    def recv_message(id)
+      channel = Channel(String).new
+      channels[id] = channel
+      channel.receive
+    end
+
+    # Processes *document* as if it was sent by the remote end.
+    def process_document(document : String)
+      return unless count_incoming_message
+      if Message.from_json(document).response?
+        process_response(document)
+      else
+        process_request(document)
+      end
+    rescue error
+      fatal_remote_error.emit document, error
+    end
+
+    private def process_response(line)
+      response = EmptyResponse.from_json line
+      channel = channels.delete(response.id)
+
+      if channel
+        channel.send(line)
+      else
+        raise "Received response with unknown id=#{response.id.inspect}"
+      end
+    end
+
+    private def process_request(line)
+      request = Request.from_json line
+      invoke_from_remote request, line
+    end
+  end
+end

--- a/src/json_rpc/stream_client.cr
+++ b/src/json_rpc/stream_client.cr
@@ -34,7 +34,7 @@ module JsonRpc
     #
     # If you did not do anything fancy, don't call this method.
     def run
-      spawn{ read_loop }
+      spawn { read_loop }
     end
 
     # Interface for `Client`

--- a/src/json_rpc/stream_client.cr
+++ b/src/json_rpc/stream_client.cr
@@ -1,8 +1,10 @@
-require "./message"
+require "./stream"
 
 module JsonRpc
   # Implements JSON-RPC over a persistant data stream.
   class StreamClient < Client
+    include Stream
+
     SIZE_LIMIT = 2 * 1024 * 1024 # 2MiB
 
     getter stream : DocumentStream
@@ -13,8 +15,6 @@ module JsonRpc
     # Maximum request size limit.  If a client exceeds this, it will be
     # disconnected.  Defaults to `SIZE_LIMIT`
     property request_size_limit : Int32 = SIZE_LIMIT
-
-    @channels = {} of IdType => Channel(String)
 
     # Creates a streaming client from *stream*.  If *run* is `true`, the client will
     # start accepting messages right away.  If you choose to pass `false`, then
@@ -39,17 +39,10 @@ module JsonRpc
       spawn { read_loop }
     end
 
-    # Interface for `Client`
+    # Interface for `JsonRpc::Client`
     def send_message(_id, message_data)
       @stream.send_document message_data
       nil
-    end
-
-    # ditto
-    def recv_message(id)
-      channel = Channel(String).new
-      @channels[id] = channel
-      channel.receive
     end
 
     # Runs the read-loop in the current fiber, blocking it.  See `#run`.
@@ -57,18 +50,6 @@ module JsonRpc
       while @running
         read_once
       end
-    end
-
-    # Processes *document* as if it was sent by the remote end.
-    def process_document(document : String)
-      return unless count_incoming_message
-      if Message.from_json(document).response?
-        process_response(document)
-      else
-        process_request(document)
-      end
-    rescue error
-      fatal_remote_error.emit document, error
     end
 
     # Waits for exactly one document to arrive and processes it.
@@ -79,22 +60,6 @@ module JsonRpc
       close
     rescue error
       fatal_remote_error.emit doc, error
-    end
-
-    private def process_response(line)
-      response = EmptyResponse.from_json line
-      channel = @channels.delete(response.id)
-
-      if channel
-        channel.send(line)
-      else
-        raise "Received response with unknown id=#{response.id.inspect}"
-      end
-    end
-
-    private def process_request(line)
-      request = Request(JSON::Any).from_json line
-      invoke_from_remote request, line
     end
 
     def inspect(io)

--- a/src/json_rpc/stream_client.cr
+++ b/src/json_rpc/stream_client.cr
@@ -1,3 +1,5 @@
+require "./message"
+
 module JsonRpc
   # Implements JSON-RPC over a persistant data stream.
   class StreamClient < Client
@@ -60,9 +62,7 @@ module JsonRpc
     # Processes *document* as if it was sent by the remote end.
     def process_document(document : String)
       return unless count_incoming_message
-      msg = Message.from_json document
-
-      if msg.response?
+      if Message.from_json(document).response?
         process_response(document)
       else
         process_request(document)

--- a/src/json_rpc/websocket_client.cr
+++ b/src/json_rpc/websocket_client.cr
@@ -11,7 +11,7 @@ module JsonRpc
 
     getter socket : HTTP::WebSocket
 
-    # Creates a WebSocket client from `HTTP::WebSocket`*.
+    # Creates a `WebSocketClient` from a `HTTP::WebSocket`.
     # If *run* is `true`, the client will start accepting messages right away.
     # If you choose to pass `false`, then make sure to call `#run` some time
     # afterwards manually, even if you're only calling remote methods.
@@ -21,8 +21,8 @@ module JsonRpc
       self.run if run
     end
 
-    # Starts the WebSocket read-loop in a background fiber.
-    # Make sure to onlyicall this method once, and only if you passed `false`
+    # Starts the `HTTP::WebSocket` read-loop in a background fiber.
+    # Make sure to only call this method once, and only if you passed `false`
     # for *run* to the constructor.
     #
     # If you did not do anything fancy, don't call this method.

--- a/src/json_rpc/websocket_client.cr
+++ b/src/json_rpc/websocket_client.cr
@@ -1,0 +1,48 @@
+require "http/web_socket"
+
+require "./stream"
+
+module JsonRpc
+  # Implements JSON-RPC over WebSocket.
+  class WebSocketClient < Client
+    include Stream
+
+    getter remote_address : String
+
+    getter socket : HTTP::WebSocket
+
+    # Creates a WebSocket client from `HTTP::WebSocket`*.
+    # If *run* is `true`, the client will start accepting messages right away.
+    # If you choose to pass `false`, then make sure to call `#run` some time
+    # afterwards manually, even if you're only calling remote methods.
+    def initialize(@socket, @remote_address, run = true)
+      socket.on_message { |document| process_document(document) }
+      socker.on_close { close rescue nil }
+      self.run if run
+    end
+
+    # Starts the WebSocket read-loop in a background fiber.
+    # Make sure to onlyicall this method once, and only if you passed `false`
+    # for *run* to the constructor.
+    #
+    # If you did not do anything fancy, don't call this method.
+    def run
+      spawn { socket.run }
+    end
+
+    # Interface for `JsonRpc::Client`
+    def send_message(_id, message_data : String)
+      socket.send(message_data)
+      nil
+    end
+
+    def close
+      super()
+      socket.close
+    end
+
+    def inspect(io)
+      io << "<WebSocket/" << remote_address << ">"
+    end
+  end
+end

--- a/src/json_rpc/websocket_client.cr
+++ b/src/json_rpc/websocket_client.cr
@@ -15,9 +15,9 @@ module JsonRpc
     # If *run* is `true`, the client will start accepting messages right away.
     # If you choose to pass `false`, then make sure to call `#run` some time
     # afterwards manually, even if you're only calling remote methods.
-    def initialize(@socket, @remote_address, run = true)
+    def initialize(@socket, @remote_address, run : Bool = true)
       socket.on_message { |document| process_document(document) }
-      socker.on_close { close rescue nil }
+      socket.on_close { close rescue nil }
       self.run if run
     end
 
@@ -31,7 +31,7 @@ module JsonRpc
     end
 
     # Interface for `JsonRpc::Client`
-    def send_message(_id, message_data : String)
+    protected def send_message(_id, message_data : String)
       socket.send(message_data)
       nil
     end


### PR DESCRIPTION
Includes changes made by @watsy0007

## Features

- `JsonRpc::WebSocketClient`
- Migrate to `JSON::Serializable`
- Major simplification of the RPC interface

## Changes

- Slight performance improvement in `TcpClient`
- Conform to [ameba](https://github.com/ameba-crystal/ameba) styling 

## Breaking Changes

- Request made via `Client#call` previously required the `response_type` to be wrapped in a `Response(T)`, now you can pass `T` directly
